### PR TITLE
Nothing

### DIFF
--- a/Execution - Suspicious Proccess
+++ b/Execution - Suspicious Proccess
@@ -1,0 +1,23 @@
+logsource:
+  category: process_creation
+  product: windows
+detection:
+  selection:
+    ParentImage|startswith: 'C:\Users\Public\'
+    CommandLine|contains: 
+      - 'powershell'
+      - 'cmd.exe /c '
+      - 'cmd /c '
+      - 'wscript.exe'
+      - 'cscript.exe'
+      - 'bitsadmin'
+      - 'certutil'
+      - 'mshta.exe'
+  condition: selection
+fields:
+  - ComputerName
+  - User
+  - CommandLine
+falsepositives:
+  - Unknown
+level: high


### PR DESCRIPTION
title: Parent in Public Folder Suspicious Process
status: experimental
author: florian Roth
description: This rule detects suspicious processes with parent images located in the C:\Users\Public folder
references:
  - https://redcanary.com/blog/blackbyte-ransomware/
date: 2022/02/25
logsource:
  category: process_creation
  product: windows
detection:
  selection:
    ParentImage|startswith: 'C:\Users\Public\'
    CommandLine|contains: 
      - 'powershell'
      - 'cmd.exe /c '
      - 'cmd /c '
      - 'wscript.exe'
      - 'cscript.exe'
      - 'bitsadmin'
      - 'certutil'
      - 'mshta.exe'
  condition: selection
fields:
  - ComputerName
  - User
  - CommandLine
falsepositives:
  - Unknown
level: high